### PR TITLE
Fixed typo "memeber" to "member"

### DIFF
--- a/Source/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSettings.cs
+++ b/Source/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSettings.cs
@@ -230,7 +230,7 @@ namespace PlayFab.PfEditor
                 var studio = GetStudioForTitleId(PlayFabEditorDataService.SharedSettings.TitleId);
                 if (string.IsNullOrEmpty(studio.Id))
                     using (new UnityHorizontal(PlayFabEditorHelper.uiStyle.GetStyle("gpStyleClear")))
-                        GUILayout.Label("You are using a TitleId to which you are not a memeber. A title administrator can approve access for your account.", PlayFabEditorHelper.uiStyle.GetStyle("orTxt"));
+                        GUILayout.Label("You are using a TitleId to which you are not a member. A title administrator can approve access for your account.", PlayFabEditorHelper.uiStyle.GetStyle("orTxt"));
 
                 PlayFabGuiFieldHelper.SuperFancyDropdown(labelWidth, "STUDIO: ", studio, PlayFabEditorDataService.AccountDetails.studios, eachStudio => eachStudio.Name, OnStudioChange, PlayFabEditorHelper.uiStyle.GetStyle("gpStyleClear"));
                 studio = GetStudioForTitleId(PlayFabEditorDataService.SharedSettings.TitleId); // This might have changed above, so refresh it


### PR DESCRIPTION
Noticed this when you go inside Unity -> Window -> PlayFab -> Editor Extensions. Then inside the editor go to "SETTINGS" and under "PROJECT" select _OVERRIDE_ as your studio, you'll see the text with this typo popping up.