### PR TITLE
Fix to always show edex window (sometimes it doesn't work)

### DIFF
--- a/Source/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
+++ b/Source/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
@@ -74,12 +74,13 @@ namespace PlayFab.PfEditor
             }
 
             window = GetWindow<PlayFabEditor>(inspWndType);
+            window.Show();
             window.titleContent = new GUIContent("PlayFab EdEx");
             PlayFabEditorPrefsSO.Instance.PanelIsShown = true;
         }
 
         [InitializeOnLoad]
-        public class Startup
+        public static class Startup
         {
             static Startup()
             {


### PR DESCRIPTION
After changing some code that gives errors edex window disappears/crashes and doesn't appear anymore after fixing errors. This commit made it always work for me.