### PR TITLE
Update PlayFabEditorExtensions.asmdef

### DIFF
--- a/Source/Assets/PlayFabEditorExtensions/PlayFabEditorExtensions.asmdef
+++ b/Source/Assets/PlayFabEditorExtensions/PlayFabEditorExtensions.asmdef
@@ -1,3 +1,14 @@
 ﻿{
-	"name": "PlayFabEditorExtensions"
+    "name": "PlayFabEditorExtensions",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }


### PR DESCRIPTION
At this moment, the .asmdef will force the EditorExtensions into their own dll (not wrapped into Unity's Editor dll) Which has the consequence that a CompilationPipeline will return the editor extensions when Play is passed in (rather than Editor which it should show up in).